### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/LayoutExper/Base.lproj/Main.storyboard
+++ b/LayoutExper/Base.lproj/Main.storyboard
@@ -68,23 +68,18 @@
                                     </tableView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="NB6-Tx-whX" firstAttribute="width" secondItem="pZE-qo-pnX" secondAttribute="width" multiplier="0.45" priority="999" id="4R5-Yj-wc3"/>
-                                    <constraint firstItem="NB6-Tx-whX" firstAttribute="leading" secondItem="pZE-qo-pnX" secondAttribute="leading" priority="999" id="Qsr-ff-xjz"/>
-                                    <constraint firstItem="NB6-Tx-whX" firstAttribute="height" secondItem="pZE-qo-pnX" secondAttribute="height" multiplier="0.3" priority="999" id="dy5-M5-wlO"/>
-                                    <constraint firstItem="NB6-Tx-whX" firstAttribute="top" secondItem="pZE-qo-pnX" secondAttribute="top" priority="999" id="nlb-z7-3nX"/>
+                                    <constraint firstItem="NB6-Tx-whX" firstAttribute="width" secondItem="pZE-qo-pnX" secondAttribute="width" multiplier="0.45" priority="750" id="4R5-Yj-wc3"/>
+                                    <constraint firstItem="NB6-Tx-whX" firstAttribute="height" secondItem="pZE-qo-pnX" secondAttribute="height" multiplier="0.3" priority="750" id="dy5-M5-wlO"/>
                                 </constraints>
                                 <variation key="default">
                                     <mask key="constraints">
                                         <exclude reference="4R5-Yj-wc3"/>
-                                        <exclude reference="Qsr-ff-xjz"/>
                                     </mask>
                                 </variation>
                                 <variation key="heightClass=compact-widthClass=compact" axis="horizontal">
                                     <mask key="constraints">
                                         <include reference="4R5-Yj-wc3"/>
-                                        <include reference="Qsr-ff-xjz"/>
                                         <exclude reference="dy5-M5-wlO"/>
-                                        <exclude reference="nlb-z7-3nX"/>
                                     </mask>
                                 </variation>
                             </stackView>


### PR DESCRIPTION
The leading & top constraints of the **Info Stack View** can completely be eliminated. The leading edge or the top edge is already laid out with respect to **Outer Stack View**.

The width & height constraints can have priority of standard value 750 instead of 999 (which, to me, is non-standard).